### PR TITLE
fix: Add handling for missing VideoFormat on Linux

### DIFF
--- a/src/capturer/engine/linux/mod.rs
+++ b/src/capturer/engine/linux/mod.rs
@@ -158,6 +158,12 @@ fn process_callback(stream: &StreamRef, user_data: &mut ListenerUserData) {
                     height: frame_size.height as i32,
                     data: frame_data,
                 })),
+                VideoFormat::RGBA => user_data.tx.send(Frame::RGBx(RGBxFrame {
+                    display_time: timestamp as u64,
+                    width: frame_size.width as i32,
+                    height: frame_size.height as i32,
+                    data: frame_data,
+                })),
                 _ => panic!("Unsupported frame format received"),
             } {
                 eprintln!("{e}");


### PR DESCRIPTION
In the current code, VideoFormat::RGBA is included in the list of output formats for the buffer
https://github.com/CapSoftware/scap/blob/92cabc5b4628a238b626a085b04cc0be0746cd1e/src/capturer/engine/linux/mod.rs#L213-L222
but the case where VideoFormat is VideoFormat::RGBA is not handled
https://github.com/CapSoftware/scap/blob/92cabc5b4628a238b626a085b04cc0be0746cd1e/src/capturer/engine/linux/mod.rs#L136-L164

This PR will fix it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing and transmitting video frames in the RGBA format on Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->