### PR TITLE
Fix windows compilation because of timestamp typo

### DIFF
--- a/src/capturer/engine/win/mod.rs
+++ b/src/capturer/engine/win/mod.rs
@@ -76,7 +76,7 @@ impl GraphicsCaptureApiHandler for Capturer {
         frame: &mut WCFrame,
         _: InternalCaptureControl,
     ) -> Result<(), Self::Error> {
-        let elapsed = frame.timespan().Duration - self.start_time.0;
+        let elapsed = frame.timestamp().Duration - self.start_time.0;
         let display_time = self
             .start_time
             .1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod targets;
 mod utils;
 
 // Helper Methods
-pub use targets::{get_all_targets, get_main_display};
+pub use targets::{get_all_targets, get_main_display, get_target_dimensions};
 pub use targets::{Display, Target};
 pub use utils::has_permission;
 pub use utils::is_supported;


### PR DESCRIPTION
Am not able to compile scap on windows, because of this typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public API now exposes target/display dimensions.
  - Frame payloads unified under a single video frame representation for consistent handling.

- **Bug Fixes**
  - Improved frame timing accuracy and reduced capture/playback drift by correcting elapsed-time calculation and standardizing display-time sourcing across platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->