### PR TITLE
fix/feat: SystemTime instead of timestamp

### DIFF
--- a/src/frame/video.rs
+++ b/src/frame/video.rs
@@ -14,6 +14,8 @@ pub struct YUVFrame {
 #[derive(Debug, Clone)]
 pub struct RGBFrame {
     pub display_time: SystemTime,
+    pub processed_time: SystemTime,
+    pub sequence: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
@@ -29,6 +31,8 @@ pub struct RGB8Frame {
 #[derive(Debug, Clone)]
 pub struct RGBxFrame {
     pub display_time: SystemTime,
+    pub processed_time: SystemTime,
+    pub sequence: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
@@ -37,6 +41,8 @@ pub struct RGBxFrame {
 #[derive(Debug, Clone)]
 pub struct XBGRFrame {
     pub display_time: SystemTime,
+    pub processed_time: SystemTime,
+    pub sequence: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
@@ -45,6 +51,8 @@ pub struct XBGRFrame {
 #[derive(Debug, Clone)]
 pub struct BGRxFrame {
     pub display_time: SystemTime,
+    pub processed_time: SystemTime,
+    pub sequence: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
@@ -53,6 +61,8 @@ pub struct BGRxFrame {
 #[derive(Debug, Clone)]
 pub struct BGRFrame {
     pub display_time: SystemTime,
+    pub processed_time: SystemTime,
+    pub sequence: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
@@ -61,6 +71,8 @@ pub struct BGRFrame {
 #[derive(Debug, Clone)]
 pub struct BGRAFrame {
     pub display_time: SystemTime,
+    pub processed_time: SystemTime,
+    pub sequence: u64,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,


### PR DESCRIPTION
Added sequence numbers as well.
Created function to grab latest buffer instead of latest ready one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced timestamp tracking for video frames with precise processing and display time information.
  * Video frames now include sequence identifiers for improved frame ordering and synchronization.
  * Extended frame metadata to provide more comprehensive timing details for video capture operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->