### PR TITLE
Implement Send for Display and Window

### DIFF
--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -10,6 +10,9 @@ mod win;
 #[cfg(target_os = "linux")]
 mod linux;
 
+#[cfg(target_os = "windows")]
+unsafe impl Send for Window {}
+
 #[derive(Debug, Clone)]
 pub struct Window {
     pub id: u32,
@@ -21,6 +24,9 @@ pub struct Window {
     #[cfg(target_os = "macos")]
     pub raw_handle: cidre::cg::WindowId,
 }
+
+#[cfg(target_os = "windows")]
+unsafe impl Send for Display {}
 
 #[derive(Debug, Clone)]
 pub struct Display {


### PR DESCRIPTION
Fix #145

Inspired from https://github.com/nashaofu/xcap/pull/231

This allow to do:

```rs
let mut capturer = Capturer::build(Options {/* ... */})?;

// Start capturing
capturer.start_capture();

spawn(move || {
    capturer; // !!! This move isn't allowed on Windows without Send trait
});
```